### PR TITLE
A prototypal variant

### DIFF
--- a/DateHelpers.js
+++ b/DateHelpers.js
@@ -67,7 +67,14 @@ const format = (date, formatStr = "yyyy/mm/dd hh:mi:ss", language) => {
   return (formatStr.replace(moduleData.formattingRegex, found => dateValueReplacements[found] || found)).split(/~/).join("");
 };
 const dateAdd = (date, part, val = 0) => dateGetOrSet[part](date.value, (+val || 0) + dateGetOrSet[part](date.value)) && date;
-const setValidDate = param => param && !isNaN(param) ? param : new Date();
+const setValidDate = param => {
+
+  if (param && param.constructor === String && param.split(/[-/]/).length < 3) {
+    param = undefined;
+  }
+  const tryDate = (param && new Date(param)) || NaN;
+  return !isNaN(tryDate) ? tryDate : new Date();
+}
 
 module.exports = {
   moduleData: moduleData,

--- a/DateHelpers.js
+++ b/DateHelpers.js
@@ -3,7 +3,7 @@ const {
   translations
 } = require("./Translations");
 let moduleData = {
-  formattingRegex: null,
+  formattingRegex: /(\byyyy\b)|(\bm\b)|(\bd\b)|(\bh\b)|(\bmi\b)|(\bs\b)|(\bms\b)|(\bwd\b)|(\bmm\b)|(\bdd\b)|(\bhh\b)|(\bMI\b)|(\bS\b)|(\bMS\b)|(\bM\b)|(\bMM\b)|(\bdow\b)|(\bDOW\b)/g,
   defaultLanguage: "EN"
 };
 const padLeft = (n, len = 2, chr = "0") => len > (`${n}`).length && `0${new Array(len - (`${n}`).length).join(chr || "0")}${n}` || n;
@@ -25,7 +25,7 @@ const dateGetOrSet = Object.entries(dateUnits)
     [part[0]]: (date, value) => date[`${value ? `set` : `get`}${part[1]}`](+value)
   }))
   .reduce((prts, part) => objMerge(prts, part), {});
-const currentDateValues = (currentXDateValue, language) => {
+const currentDateValues = (currentXDateValue, language = moduleData.defaultLanguage) => {
   let currentValues = {
     yyyy: dateGetOrSet.year(currentXDateValue),
     m: dateGetOrSet.month(currentXDateValue) + 1,
@@ -48,10 +48,11 @@ const currentDateValues = (currentXDateValue, language) => {
     dow: translations.weekdays.short[language][currentValues.wd],
     DOW: translations.weekdays.full[language][currentValues.wd]
   });
-  moduleData.formattingRegex = moduleData.formattingRegex ||
-    new RegExp("~|" + Object.keys(currentValues).reduce((p, key) => p.concat(`(\\b${key}\\b)`), []).join("|"), "g");
   return currentValues;
 };
+const setFormattingRegex = () => 
+  new RegExp(Object.keys(currentValues(new Date(), moduleData.defaultLanguage))
+    .reduce((p, key) => p.concat(`(\\b${key}\\b)`), []).join("|"), "g");
 const dateSet = (date, part, val) => {
   const setMonthValue = val => val < 1 || !val ? 12 : val - 1;
   val = +val;
@@ -66,16 +67,17 @@ const format = (date, formatStr = "yyyy/mm/dd hh:mi:ss", language) => {
   return (formatStr.replace(moduleData.formattingRegex, found => dateValueReplacements[found] || found)).split(/~/).join("");
 };
 const dateAdd = (date, part, val = 0) => dateGetOrSet[part](date.value, (+val || 0) + dateGetOrSet[part](date.value)) && date;
-const setValidDate = param => !isNaN(param) ? param : new Date();
+const setValidDate = param => param && !isNaN(param) ? param : new Date();
 
 module.exports = {
+  moduleData: moduleData,
   dateSet: dateSet,
+  currentDateValues,
   dateUnits: dateUnits,
   setLanguage: setLanguage,
   format: format,
   dateAdd: dateAdd,
   setValidDate: setValidDate,
-  moduleData: moduleData,
   objMerge: objMerge,
-  units: objUnits
+  units: objUnits,
 };

--- a/Formats.js
+++ b/Formats.js
@@ -2,6 +2,7 @@ module.exports = {
     // ISO
     dateISO: (separator = "-") => `yyyy${separator}mm${separator}dd`,
     dateTimeISOFull: (separator = "-") => `yyyy${separator}mm${separator}dd hh:MI:S.MS`,
+    dateTimeISOFullZulu: (separator = "-") => `yyyy${separator}mm${separator}dd~T~hh:MI:S.MS~Z`,
     dateTimeISOSeconds: (separator = "-") => `yyyy${separator}mm${separator}dd hh:MI:S`,
     dateTimeISO: (separator = "-") => `yyyy${separator}mm${separator}dd hh:MI`,
     // EN

--- a/index.js
+++ b/index.js
@@ -24,5 +24,5 @@ Instance.prototype = {
 module.exports = {
   formatStrings: require("./Formats"),
   XDate: (someDate, language = moduleData.defaultLanguage) =>
-      new Instance(setValidDate(someDate ? new Date(someDate) : new Date()), language),
+      new Instance(setValidDate(someDate), language),
 };

--- a/index.js
+++ b/index.js
@@ -1,32 +1,28 @@
+const {
+  dateAdd,
+  dateSet,
+  setLanguage,
+  format,
+  units,  
+  setValidDate,
+  moduleData,
+} = require("./DateHelpers");
+
+function Instance(date, language) {
+  this.value = date;
+  this.language = language;
+} 
+
+Instance.prototype = {
+  add(val, unit = units.day) { return dateAdd(this, unit, val); },
+  setUnit(val, unit) { return dateSet(this, unit, val); },
+  setLanguage(language) { return setLanguage(this, language); },
+  format(formatStr, language) {return format(this, formatStr, language); },
+  units: units,
+};
+
 module.exports = {
-  XDate: (() => {
-    const {
-      dateSet,
-      dateUnits,
-      setLanguage,
-      format,
-      dateAdd,
-      setValidDate,
-      moduleData,
-      objMerge,
-      units
-    } = require("./DateHelpers");
-
-    function XDateCtor(date, language) {
-      this.value = date;
-      this.language = language;
-    } 
-
-    XDateCtor.prototype = {
-      add(val, unit = units.day) { return dateAdd(this, unit, val); },
-      setUnit(val, unit) { return dateSet(this, unit, val); },
-      setLanguage(language) { return setLanguage(this, language); },
-      format(formatStr, language) {return format(this, formatStr, language); },
-      units: units,
-    };
-
-    return (someDate, language = moduleData.defaultLanguage) =>
-      new XDateCtor(setValidDate(someDate ? new Date(someDate) : new Date()), language);
-  })(),
   formatStrings: require("./Formats"),
+  XDate: (someDate, language = moduleData.defaultLanguage) =>
+      new Instance(setValidDate(someDate ? new Date(someDate) : new Date()), language),
 };

--- a/index.js
+++ b/index.js
@@ -12,19 +12,21 @@ module.exports = {
       units
     } = require("./DateHelpers");
 
-    const Create = dateObj => objMerge(dateObj, {
-      add: (val, unit = units.day) => dateAdd(dateObj, unit, val),
-      setUnit: (val, unit) => dateSet(dateObj, unit, val),
-      setLanguage: language => setLanguage(dateObj, language),
-      format: (formatStr, language) => format(dateObj, formatStr, language),
+    function XDateCtor(date, language) {
+      this.value = date;
+      this.language = language;
+    } 
+
+    XDateCtor.prototype = {
+      add(val, unit = units.day) { return dateAdd(this, unit, val); },
+      setUnit(val, unit) { return dateSet(this, unit, val); },
+      setLanguage(language) { return setLanguage(this, language); },
+      format(formatStr, language) {return format(this, formatStr, language); },
       units: units,
-    });
+    };
 
     return (someDate, language = moduleData.defaultLanguage) =>
-      Create({
-        value: setValidDate(someDate ? new Date(someDate) : new Date()),
-        language: language
-      });
+      new XDateCtor(setValidDate(someDate ? new Date(someDate) : new Date()), language);
   })(),
   formatStrings: require("./Formats"),
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "NICon/Renzo Kooi",
   "license": "ISC",
   "name": "date-extension",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A simple Date helper library for formatting and simple arithmetic operations",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,24 @@ const now = XDate();
 **Note**: The module contains tests. Reading the tests.js-file may provide more information on the usage.
 
 # Available methods
+
+## XDate
+**Parameters** `date, language`
+
+`date` can be: nothing, a date string (with at least year, month and date (like "2018/03/01")) or a Date (new Date). An invalid date becomes the current date.
+`language` Possible values are: empty, "EN", "NL", "DE" or "FR". Default is "EN"
+
+Examples
+
+```javascript
+const now = XDate(); // formatting language default English
+const nowToo = XDate("2019");
+const nowToo2 = XDate("no dice");
+const then = XDate("2018/04/06", "NL"); // formatting language will be dutch now
+const futureDate = XDate(new Date("2050/01/01"), "DE"); // formatting language will be  german
+// etc.
+```
+
 ## add
 
 **Parameters** `value = 0, unit`

--- a/test.js
+++ b/test.js
@@ -6,7 +6,9 @@ const {
 const chai = require("chai");
 const assert = chai["assert"];
 const expect = chai["expect"];
-const units = XDate().units;
+const DTHelpers = require("./DateHelpers");
+const units = DTHelpers.units;
+
 const dateMethodFromUnit = {
     day: "Date",
     month: "Month",
@@ -19,12 +21,20 @@ const dateMethodFromUnit = {
 };
 
 const tests = allTests();
-describe("DateHelper", () => {
+describe("Date Extensions", () => {
   describe("√ General/approval", () => {
     it("Can create an extended Date", tests.createdValue);
     it("Methods approval", tests.methodsApproval);
     it("Properties approval", tests.propsApproval);
     it("Leftpad values", tests.leftPadding);
+  });
+  describe("√ Helper methods", () => {
+    it("setValidDate without parameter delivers Date obj (i.c. now)", () => assert.equal(DTHelpers.setValidDate() instanceof Date, true));
+    it("currentDateValues month value", () => assert.equal(DTHelpers.currentDateValues(new Date()).m, new Date().getMonth()+1));
+    it("currentDateValues monthString EN", () => assert.equal(DTHelpers.currentDateValues(new Date("2018/06/01"), "EN").MM, "June"));
+    it("currentDateValues monthString NL", () => assert.equal(DTHelpers.currentDateValues(new Date("2018/06/01"), "NL").MM, "Juni"));
+    it("currentDateValues monthString DE", () => assert.equal(DTHelpers.currentDateValues(new Date("2018/06/01"), "DE").MM, "Juni"));
+    it("currentDateValues monthString FR", () => assert.equal(DTHelpers.currentDateValues(new Date("2018/06/01"), "FR").MM, "Juin"));
   });
   describe("√ Set Datepart (setUnit)", () => {
     const testDate = "2017/02/05";
@@ -93,6 +103,7 @@ describe("DateHelper", () => {
     const fixed = XDate("2015/03/18 11:03");
     it("dateISO (yyyy-mm-dd)", () => assert.equal(fixed.format(formatStrings.dateISO()), "2015-03-18"));
     it("dateTimeISOFull (yyyy-mm-dd hh:MI:S.MS)", () => assert.equal(fixed.format(formatStrings.dateTimeISOFull()), "2015-03-18 11:03:00.000"));
+    it("dateTimeISOFullZulu (yyyy-mm-dd~T~hh:MI:S.MS~Z)", () => assert.equal(fixed.format(formatStrings.dateTimeISOFullZulu()), "2015-03-18T11:03:00.000Z"));
     it("dateTimeISOSeconds (yyyy-mm-dd hh:MI:S)", () => assert.equal(fixed.format(formatStrings.dateTimeISOSeconds()), "2015-03-18 11:03:00"));
     it("dateTimeISO (yyyy-mm-dd hh:MI)", () => assert.equal(fixed.format(formatStrings.dateTimeISO()), "2015-03-18 11:03"));
   });

--- a/test.js
+++ b/test.js
@@ -139,6 +139,11 @@ describe("DateHelper", () => {
 
 });
 
+const used = process.memoryUsage();
+for (let key in used) {
+  console.log(`${key} ${Math.round(used[key] / 1024 / 1024 * 100) / 100} MB`);
+}
+
 function allTests() {
   const now = XDate();
   const fixed = XDate("2018/07/11");

--- a/test.js
+++ b/test.js
@@ -29,7 +29,9 @@ describe("Date Extensions", () => {
     it("Leftpad values", tests.leftPadding);
   });
   describe("√ Helper methods", () => {
-    it("setValidDate without parameter delivers Date obj (i.c. now)", () => assert.equal(DTHelpers.setValidDate() instanceof Date, true));
+    it("setValidDate without parameter delivers current date", () => assert.equal(DTHelpers.setValidDate().toDateString(), new Date().toDateString()));
+    it("setValidDate with invalid parameter delivers current date", () => assert.equal(DTHelpers.setValidDate("2018").toString(), new Date().toString()));
+    it("setValidDate with string parameter", () => assert.equal(DTHelpers.setValidDate("2018/04/05").toString(), new Date("2018/04/05").toString()));
     it("currentDateValues month value", () => assert.equal(DTHelpers.currentDateValues(new Date()).m, new Date().getMonth()+1));
     it("currentDateValues monthString EN", () => assert.equal(DTHelpers.currentDateValues(new Date("2018/06/01"), "EN").MM, "June"));
     it("currentDateValues monthString NL", () => assert.equal(DTHelpers.currentDateValues(new Date("2018/06/01"), "NL").MM, "Juni"));

--- a/test.js
+++ b/test.js
@@ -166,8 +166,15 @@ function allTests() {
       assert.equal(x.add(33, units.day).format("m"), 8);
       assert.equal(x.format("d"), 13);
     },
-    methodsApproval: () => assert.equal(Object.keys(now).filter(k => now[k] instanceof Function).sort().toString(), "add,format,setLanguage,setUnit"),
-    propsApproval: () => assert.equal(Object.keys(now).filter(k => !(now[k] instanceof Function)).sort().toString(), "language,units,value"),
+    methodsApproval: () => {
+      const keys = Object.getOwnPropertyNames(Object.getPrototypeOf(now)) || Object.keys(now);
+      assert.equal(keys.filter(k => (now[k] || now.prototype[k]) instanceof Function).sort().toString(), "add,format,setLanguage,setUnit")
+    },
+    propsApproval: () => {
+      // todo: hier moet units nog bij (zit evt in prototype)
+      const keys = Object.keys(now);
+      assert.equal(keys.filter(k => !(now[k] instanceof Function)).sort().toString(), "language,units,value");
+    },
     canFormatDefault: () => assert.equal(fixed.format("yyyy-mm-dd hh:MI"), "2018-07-11 00:00"),
     canFormatDefaultWithStrings: () => assert.equal(fixed.format("yyyy-mm-dd~T~hh:MI:S:MS~Z"), "2018-07-11T00:00:00:000Z"),
     formatENMonthLong: () => assert.equal(fixedEN.format("MM"), "July"),

--- a/test.js
+++ b/test.js
@@ -167,14 +167,16 @@ function allTests() {
       assert.equal(x.format("d"), 13);
     },
     methodsApproval: () => {
-      console.log(Object.getOwnPropertyNames(Object.getPrototypeOf(now)));
-      const keys = Object.getOwnPropertyNames(Object.getPrototypeOf(now)) || Object.keys(now);
+      let keys = Object.getOwnPropertyNames(Object.getPrototypeOf(now));
+      keys = keys.filter(k => k === "add").length ? keys : Object.keys(now);
       assert.equal(keys.filter(k => (now[k] || now.prototype[k]) instanceof Function).sort().toString(), "add,format,setLanguage,setUnit")
     },
     propsApproval: () => {
-      // todo: hier moet units nog bij (zit evt in prototype)
-      const keys = Object.keys(now);
-      assert.equal(keys.filter(k => !(now[k] instanceof Function)).sort().toString(), "language,units,value");
+      const isProto = Object.getOwnPropertyNames(Object.getPrototypeOf(now)).filter(k => k === "add").length;
+      keys =  Object.keys(now);
+      assert.equal(
+        keys.filter(k => !(now[k] instanceof Function)).sort().toString(), 
+        isProto ? "language,value" : "language,units,value");
     },
     canFormatDefault: () => assert.equal(fixed.format("yyyy-mm-dd hh:MI"), "2018-07-11 00:00"),
     canFormatDefaultWithStrings: () => assert.equal(fixed.format("yyyy-mm-dd~T~hh:MI:S:MS~Z"), "2018-07-11T00:00:00:000Z"),

--- a/test.js
+++ b/test.js
@@ -167,6 +167,7 @@ function allTests() {
       assert.equal(x.format("d"), 13);
     },
     methodsApproval: () => {
+      console.log(Object.getOwnPropertyNames(Object.getPrototypeOf(now)));
       const keys = Object.getOwnPropertyNames(Object.getPrototypeOf(now)) || Object.keys(now);
       assert.equal(keys.filter(k => (now[k] || now.prototype[k]) instanceof Function).sort().toString(), "add,format,setLanguage,setUnit")
     },


### PR DESCRIPTION
Prototypal should be more efficient. For the testset, these are the numbers (nodejs v 10.3.0). Not that impressive, I'd say

```javascript
 * prototypal tested
 * -------------------
 * rss 26.21 MB
 * heapTotal 17.3 MB
 * heapUsed 9.22 MB
 * external 0.33 MB


 * non prototypal tested
 * ------------------------
 * rss 26.4 MB
 * heapTotal 18.3 MB
 * heapUsed 9.48 MB
 * external 0.33 MB
```